### PR TITLE
Do not install testing modules with the default installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,7 @@ setup(
     author="Niels Mündler, Gerrit Beine",
     author_email="n.muendler@web.de, mail@gerritbeine.de",
     url="https://github.com/nielstron/pyfronius/",
-    py_modules=["pyfronius"],
-    package_data={
-        "pyfronius.tests.test_structure": [
-            "solar_api/v1/*.fcgi*",
-            "solar_api/v1/*.cgi*",
-            ".error.html",
-        ]
-    },
-    packages=find_packages(),
+    packages=find_packages(exclude=("pyfronius.tests", "pyfronius.tests.*")),
     install_requires=["aiohttp"],
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
As in pysyncthru, proposed by @scop, the testing modules may be excluded from the distributed version of the package. This also fixes issue #12 .