### PR TITLE
Allow trailing slashes in fronius device URL

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -11,6 +11,7 @@ import aiohttp
 import json
 import logging
 import enum
+import re
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ class Fronius:
         Constructor
         """
         self._aio_session = session
-        self.url = url
+        self.url = re.sub(r"/+$", "", url)
         self.api_version = api_version
         self.base_url = API_BASEPATHS.get(API_VERSION)
 


### PR DESCRIPTION
Hey,

after looking into https://github.com/home-assistant/core/issues/54206 opened by @ornago yesterday we figured out that Fronius has updated their API to be more strict about trailing slashes in the device URL.

We learned the hard way, that providing a trailing slash as the device URL did work with the old firmware 3.17.3-1  but does not work anymore with the most recent version 3.18.7-1. However, we originally had configured it with a trailing slash and that broke everything.

A `curl` on `http://192.168.0.26//solar_api/GetAPIVersion.cgi` (mind the `//`!) worked in the old firmware, but results in a 404 in the new one so we had all sorts of side effects here in pyfronius (such as unjustified downgrades to API Version 0, etc). 

This PR makes pyfronius more relaxed about trailing slashes in device URLs, no matter whether you provide one or not, it will trim it if it's there so we reach a defined state internally. I would argue, that a trailing slash is actually tolerable here, since it would be interpreted as a path and a path can be part of a URL - and a URL is requested in the docs.

Enjoy!

Best,
Hendrik