### PR TITLE
Except timeout for wrong url

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -124,7 +124,7 @@ class Fronius:
             async with self._aio_session.get(url) as res:
                 text = await res.text()
                 text = json.loads(text)
-        except aiohttp.ServerTimeoutError:
+        except (aiohttp.ServerTimeoutError, asyncio.TimeoutError):
             raise ConnectionError(
                 "Connection to Fronius device timed out at {}.".format(url)
             )

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -6,12 +6,11 @@ Created on 27.09.2017
 """
 
 import asyncio
+import enum
+import logging
+import re
 
 import aiohttp
-import json
-import logging
-import enum
-import re
 
 _LOGGER = logging.getLogger(__name__)
 DEGREE_CELSIUS = "°C"
@@ -122,8 +121,7 @@ class Fronius:
         """
         try:
             async with self._aio_session.get(url) as res:
-                text = await res.text()
-                text = json.loads(text)
+                result = await res.json()
         except (aiohttp.ServerTimeoutError, asyncio.TimeoutError):
             raise ConnectionError(
                 "Connection to Fronius device timed out at {}.".format(url)
@@ -132,9 +130,9 @@ class Fronius:
             raise ConnectionError(
                 "Connection to Fronius device failed at {}.".format(url)
             )
-        except json.JSONDecodeError:
+        except aiohttp.ContentTypeError:
             raise ValueError("Host returned a non-JSON reply at {}.".format(url))
-        return text
+        return result
 
     async def fetch_api_version(self):
         """

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -103,7 +103,9 @@ class Fronius:
         api_version  Version of Fronius API to use
     """
 
-    def __init__(self, session, url, api_version=API_VERSION.AUTO):
+    def __init__(
+        self, session: aiohttp.ClientSession, url: str, api_version=API_VERSION.AUTO
+    ):
         """
         Constructor
         """
@@ -121,7 +123,7 @@ class Fronius:
         """
         try:
             async with self._aio_session.get(url) as res:
-                result = await res.json()
+                result = await res.json(content_type=None)
         except (aiohttp.ServerTimeoutError, asyncio.TimeoutError):
             raise ConnectionError(
                 "Connection to Fronius device timed out at {}.".format(url)


### PR DESCRIPTION
- except timeout for wrong url
When using a wrong url (non assigned url) aiohttp raises `asyncio.TimeoutError`. This is not catched by `aiohttp.ServerTimeoutError`
- use aiohttp json decode method
This just saves an import. It does the same as `json.loads()` https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json
- isort `__init__.py`