### PR TITLE
Fix manually assigned api version basepath

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -36,7 +36,7 @@ class API_VERSION(enum.Enum):
 
 API_BASEPATHS = {
     API_VERSION.V0: "/solar_api/",
-    API_VERSION.V1: "/solar_api/v1",
+    API_VERSION.V1: "/solar_api/v1/",
 }
 
 URL_API_VERSION = "solar_api/GetAPIVersion.cgi"
@@ -121,7 +121,7 @@ class Fronius:
         if not self.url.startswith("http"):
             self.url = "http://{}".format(self.url)
         self.api_version = api_version
-        self.base_url = API_BASEPATHS.get(API_VERSION)
+        self.base_url = API_BASEPATHS.get(api_version)
 
     async def _fetch_json(self, url):
         """


### PR DESCRIPTION
`base_url` was always `None`, so `fetch_api_version()` was always called assigning the returned basepath to `fronius.base_url`. Because of this the missing `/` in the `API_BASEPATH` didn't break the unittests.