### PR TITLE
Error handling

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -7,7 +7,6 @@ Created on 27.09.2017
 
 import asyncio
 import enum
-from contextlib import suppress
 from html import unescape
 import logging
 import json
@@ -283,7 +282,14 @@ class Fronius:
         for i in device_inverter:
             requests.append(self.current_inverter_data(i))
 
-        responses = await asyncio.gather(*requests, loop=loop)
+        res = await asyncio.gather(*requests, loop=loop, return_exceptions=True)
+        responses = []
+        for resopnse in res:
+            if isinstance(resopnse, FroniusError):
+                _LOGGER.warning(resopnse)
+                responses.append({})
+                continue
+            responses.append(resopnse)
         return responses
 
     @staticmethod

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -7,6 +7,7 @@ Created on 27.09.2017
 
 import asyncio
 import enum
+from contextlib import suppress
 from html import unescape
 import logging
 import json
@@ -88,6 +89,23 @@ URL_LOGGER_INFO = {
     API_VERSION.V1: "GetLoggerInfo.cgi",
 }
 
+HEADER_STATUS_CODES = {
+    0: "OKAY",
+    1: "NotImplemented",
+    2: "Uninitialized",
+    3: "Initialized",
+    4: "Running",
+    5: "Timeout",
+    6: "Argument Error",
+    7: "LNRequestError",
+    8: "LNRequestTimeout",
+    9: "LNParseError",
+    10: "ConfigIOError",
+    11: "NotSupported",
+    12: "DeviceNotAvailable",
+    255: "UnknownError",
+}
+
 
 class FroniusError(Exception):
     """
@@ -113,6 +131,18 @@ class InvalidAnswerError(ValueError, FroniusError):
     """
     An error to be raised if the host Fronius device could not answer a request
     """
+
+
+class BadStatusError(FroniusError):
+    """A bad status code was returned."""
+    def __init__(self, endpoint: str, code: int, reason=None) -> None:
+        """Instantiate exception."""
+        message = (
+            f"BadStatusError at {endpoint}. "
+            f"Code: {code} - {HEADER_STATUS_CODES.get(code, 'unknown status code')}. "
+            f"Reason: {reason or 'unknown'}."
+        )
+        super().__init__(message)
 
 
 class Fronius:
@@ -299,6 +329,12 @@ class Fronius:
             _LOGGER.info(
                 "No header data returned from {} ({})".format(spec, spec_formattings)
             )
+        else:
+            if sensor["status"]["Code"] != 0:
+                endpoint = spec[self.api_version]
+                code = sensor["status"]["Code"]
+                reason = sensor["status"]["Reason"]
+                raise BadStatusError(endpoint, code, reason=reason)
         try:
             sensor.update(fun(res["Body"]["Data"]))
         except (TypeError, KeyError):

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -10,7 +10,7 @@ import enum
 from html import unescape
 import json
 import logging
-from typing import Any
+from typing import Any, Dict
 
 import aiohttp
 
@@ -140,7 +140,7 @@ class BadStatusError(FroniusError):
             endpoint: str,
             code: int,
             reason: str = None,
-            response: dict[str, Any] = {},
+            response: Dict[str, Any] = {},
             ) -> None:
         """Instantiate exception."""
         self.response = response

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -240,12 +240,11 @@ class Fronius:
                 )
         spec_url = spec.get(self.api_version)
         if spec_url is None:
-            _LOGGER.warning(
+            raise NotSupportedError(
                 "API version {} does not support request of {} data".format(
                     self.api_version, spec_name
                 )
             )
-            return None
         if spec_formattings:
             spec_url = spec_url.format(*spec_formattings)
 
@@ -340,8 +339,7 @@ class Fronius:
         try:
             sensor.update(Fronius._status_data(res))
         except (TypeError, KeyError):
-            # break if Data is empty
-            _LOGGER.info(
+            raise InvalidAnswerError(
                 "No header data returned from {} ({})".format(spec, spec_formattings)
             )
         else:
@@ -357,8 +355,7 @@ class Fronius:
             try:
                 sensor.update(fun(res["Body"]["LoggerInfo"]))
             except (TypeError, KeyError):
-                # break if Data is empty
-                _LOGGER.info(
+                raise InvalidAnswerError(
                     "No body data returned from {} ({})".format(spec, spec_formattings)
                 )
         return sensor

--- a/pyfronius/tests/test_web_v0.py
+++ b/pyfronius/tests/test_web_v0.py
@@ -186,34 +186,34 @@ class FroniusWebTestV0(unittest.TestCase):
         self.assertDictEqual(res, GET_INVERTER_REALTIME_DATA_SYSTEM)
 
     def test_fronius_get_meter_realtime_data_system(self):
-        res = asyncio.get_event_loop().run_until_complete(
-            self.fronius.current_system_meter_data()
-        )
-        self.assertDictEqual(res, {})
+        with self.assertRaises(pyfronius.NotSupportedError):
+            asyncio.get_event_loop().run_until_complete(
+                self.fronius.current_system_meter_data()
+            )
 
     def test_fronius_get_meter_realtime_data_device(self):
-        res = asyncio.get_event_loop().run_until_complete(
-            self.fronius.current_meter_data()
-        )
-        self.assertDictEqual(res, {})
+        with self.assertRaises(pyfronius.NotSupportedError):
+            asyncio.get_event_loop().run_until_complete(
+                self.fronius.current_meter_data()
+            )
 
     def test_fronius_get_power_flow_realtime_data(self):
-        res = asyncio.get_event_loop().run_until_complete(
-            self.fronius.current_power_flow()
-        )
-        self.assertDictEqual(res, {})
+        with self.assertRaises(pyfronius.NotSupportedError):
+            asyncio.get_event_loop().run_until_complete(
+                self.fronius.current_power_flow()
+            )
 
     def test_fronius_get_led_info_data(self):
-        res = asyncio.get_event_loop().run_until_complete(
-            self.fronius.current_led_data()
-        )
-        self.assertDictEqual(res, {})
+        with self.assertRaises(pyfronius.NotSupportedError):
+            asyncio.get_event_loop().run_until_complete(
+                self.fronius.current_led_data()
+            )
 
     def test_fronius_get_active_device_info(self):
-        res = asyncio.get_event_loop().run_until_complete(
-            self.fronius.current_active_device_info()
-        )
-        self.assertDictEqual(res, {})
+        with self.assertRaises(pyfronius.NotSupportedError):
+            asyncio.get_event_loop().run_until_complete(
+                self.fronius.current_active_device_info()
+            )
 
     def test_fronius_get_logger_info(self):
         res = asyncio.get_event_loop().run_until_complete(
@@ -228,11 +228,10 @@ class FroniusWebTestV0(unittest.TestCase):
     def test_fronius_get_no_data(self):
         # Storage data for device 0 is not provided ATM
         # TODO someone add some storage data for a device 1?
-        res = asyncio.get_event_loop().run_until_complete(
-            self.fronius.current_storage_data()
-        )
-        self.assertDictEqual(res, {})
-        # Mainly asserts that no error is thrown by illegal access!
+        with self.assertRaises(pyfronius.NotSupportedError):
+            asyncio.get_event_loop().run_until_complete(
+                self.fronius.current_storage_data()
+            )
 
     def tearDown(self):
         asyncio.get_event_loop().run_until_complete(self.session.close())

--- a/pyfronius/tests/test_web_v1.py
+++ b/pyfronius/tests/test_web_v1.py
@@ -236,12 +236,12 @@ class FroniusWebTestV1(unittest.TestCase):
     def test_fronius_get_no_data(self):
         # Storage data for device 0 is not provided ATM
         # TODO someone add some storage data for a device 1?
-        res = asyncio.get_event_loop().run_until_complete(
-            self.fronius.current_storage_data()
-        )
-        self.assertIn("timestamp", res)
-        self.assertIn("status", res)
-        # Mainly asserts that no error is thrown by illegal access!
+        with self.assertRaises(pyfronius.BadStatusError):
+            res = asyncio.get_event_loop().run_until_complete(
+                self.fronius.current_storage_data()
+            )
+            self.assertIn("timestamp", res.result)
+            self.assertIn("status", res.result)
 
     def test_fronius_fetch(self):
         res = asyncio.get_event_loop().run_until_complete(


### PR DESCRIPTION
Raise instances of `FroniusError` on invalid request responses.
`Fronius.fetch()` suppresses these errors.

- not implemented api version endpoint
- empty response
- status code not `0`
- no body in response despite status code `0`