### PR TITLE
Treat SolarNet device_id as string

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,6 +2,7 @@
 """Basic usage example and testing of pyfronius."""
 import asyncio
 import logging
+import json
 import sys
 import aiohttp
 
@@ -18,19 +19,20 @@ async def main(loop, host):
         # NOTE: configuring the wrong devices may cause Exceptions to be thrown
         res = await fronius.fetch(
             active_device_info=True,
+            inverter_info=True,
             logger_info=True,
             power_flow=True,
             system_meter=True,
             system_inverter=True,
             system_storage=True,
-            device_meter=frozenset([0]),
+            device_meter=frozenset(["0"]),
             # storage is not necessarily supported by every fronius device
-            device_storage=frozenset([0]),
-            device_inverter=frozenset([1]),
+            device_storage=frozenset(["0"]),
+            device_inverter=frozenset(["1"]),
             loop=loop,
         )
         for r in res:
-            print(r)
+            print(json.dumps(r, indent=4))
 
 
 if __name__ == "__main__":

--- a/example.py
+++ b/example.py
@@ -25,10 +25,10 @@ async def main(loop, host):
             system_meter=True,
             system_inverter=True,
             system_storage=True,
-            device_meter=frozenset(["0"]),
+            device_meter=["0"],
             # storage is not necessarily supported by every fronius device
-            device_storage=frozenset(["0"]),
-            device_inverter=frozenset(["1"]),
+            device_storage=["0"],
+            device_inverter=["1"],
             loop=loop,
         )
         for r in res:

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -261,10 +261,10 @@ class Fronius:
         system_meter=True,
         system_inverter=True,
         system_storage=True,
-        device_meter=frozenset([0]),
+        device_meter=frozenset(["0"]),
         # storage is not necessarily supported by every fronius device
-        device_storage=frozenset([0]),
-        device_inverter=frozenset([1]),
+        device_storage=frozenset(["0"]),
+        device_inverter=frozenset(["1"]),
         loop=None,
     ):
         requests = []
@@ -387,7 +387,7 @@ class Fronius:
             "current system inverter",
         )
 
-    async def current_meter_data(self, device=0):
+    async def current_meter_data(self, device: str = "0") -> Dict[str, Any]:
         """
         Get the current meter data for a device.
         """
@@ -395,7 +395,7 @@ class Fronius:
             Fronius._device_meter_data, URL_DEVICE_METER, "current meter", device
         )
 
-    async def current_storage_data(self, device=0):
+    async def current_storage_data(self, device: str = "0") -> Dict[str, Any]:
         """
         Get the current storage data for a device.
         Provides data about batteries.
@@ -413,7 +413,7 @@ class Fronius:
             Fronius._system_storage_data, URL_DEVICE_STORAGE, "current system storage"
         )
 
-    async def current_inverter_data(self, device=1):
+    async def current_inverter_data(self, device: str = "1") -> Dict[str, Any]:
         """
         Get the current inverter data of one device.
         """


### PR DESCRIPTION
It is used as key (string) in the returned json and in the sensor dicts (as keys and values).
```
    "inverters": [
        {
            "device_id": {
                "value": "1"
            },
```
In the HA integration it is passed as `int`. If we change this to `str` too we can directly use it as key for getting the `unique_id / serial_number` from a stored dict. And having a unique_id for a HA entity is a very nice thing 😃