### PR TITLE
Add support for Ohmpilot system scope request

### DIFF
--- a/example.py
+++ b/example.py
@@ -24,6 +24,7 @@ async def main(loop, host):
             power_flow=True,
             system_meter=True,
             system_inverter=True,
+            system_ohmpilot=True,
             system_storage=True,
             device_meter=["0"],
             # storage is not necessarily supported by every fronius device

--- a/pyfronius/const.py
+++ b/pyfronius/const.py
@@ -190,3 +190,12 @@ INVERTER_DEVICE_TYPE = {
     253: {"manufacturer": "Fronius", "model": "IG 20"},
     254: {"manufacturer": "Fronius", "model": "IG 15"},
 }
+
+OHMPILOT_STATE_CODES = {
+    0: "Up and running",
+    1: "Keep minimum temperature",
+    2: "Legionella protection",
+    3: "Critical fault",
+    4: "Fault",
+    5: "Boost mode",
+}

--- a/pyfronius/tests/test_structure/v1/solar_api/v1/GetOhmPilotRealtimeData.cgi?Scope=System
+++ b/pyfronius/tests/test_structure/v1/solar_api/v1/GetOhmPilotRealtimeData.cgi?Scope=System
@@ -1,0 +1,32 @@
+{
+  "Body": {
+    "Data": {
+      "0": {
+        "CodeOfError": 926,
+        "CodeOfState": 0,
+        "Details": {
+          "Hardware": "3",
+          "Manufacturer": "Fronius",
+          "Model": "Ohmpilot",
+          "Serial": "28136344",
+          "Software": "1.0.19-1"
+        },
+        "EnergyReal_WAC_Sum_Consumed": 2964307,
+        "PowerReal_PAC_Sum": 0,
+        "Temperature_Channel_1": 23.9
+      }
+    }
+  },
+  "Head": {
+    "RequestArguments": {
+      "DeviceClass": "OhmPilot",
+      "Scope": "System"
+    },
+    "Status": {
+      "Code": 0,
+      "Reason": "",
+      "UserMessage": ""
+    },
+    "Timestamp": "2019-06-24T10:10:44+02:00"
+  }
+}

--- a/pyfronius/tests/test_web_v1.py
+++ b/pyfronius/tests/test_web_v1.py
@@ -22,6 +22,7 @@ from pyfronius.tests.web_raw.v1.web_state import (
     GET_INVERTER_REALTIME_DATA_SCOPE_DEVICE,
     GET_METER_REALTIME_DATA_SYSTEM,
     GET_LOGGER_LED_INFO_STATE,
+    GET_OHMPILOT_REALTIME_DATA_SYSTEM,
     GET_POWER_FLOW_REALTIME_DATA,
     GET_LOGGER_INFO,
     GET_INVERTER_INFO,
@@ -211,6 +212,12 @@ class FroniusWebTestV1(unittest.TestCase):
         )
         self.assertDictEqual(res, GET_INVERTER_REALTIME_DATA_SYSTEM)
 
+    def test_fronius_get_ohmpilot_realtime_data_system(self):
+        res = asyncio.get_event_loop().run_until_complete(
+            self.fronius.current_system_ohmpilot_data()
+        )
+        self.assertDictEqual(res, GET_OHMPILOT_REALTIME_DATA_SYSTEM)
+
     def test_fronius_get_led_info_data(self):
         res = asyncio.get_event_loop().run_until_complete(
             self.fronius.current_led_data()
@@ -248,9 +255,11 @@ class FroniusWebTestV1(unittest.TestCase):
             self.fronius.fetch(
                 active_device_info=True,
                 inverter_info=True,
+                logger_info=True,
                 power_flow=True,
                 system_meter=True,
                 system_inverter=True,
+                system_ohmpilot=True,
                 system_storage=False,
                 device_meter={0},
                 device_storage={0},
@@ -266,6 +275,7 @@ class FroniusWebTestV1(unittest.TestCase):
                 GET_POWER_FLOW_REALTIME_DATA,
                 GET_METER_REALTIME_DATA_SYSTEM,
                 GET_INVERTER_REALTIME_DATA_SYSTEM,
+                GET_OHMPILOT_REALTIME_DATA_SYSTEM,
                 GET_METER_REALTIME_DATA_SCOPE_DEVICE,
                 GET_STORAGE_REALTIME_DATA_SCOPE_DEVICE,
                 GET_INVERTER_REALTIME_DATA_SCOPE_DEVICE,

--- a/pyfronius/tests/web_raw/v1/web_state.py
+++ b/pyfronius/tests/web_raw/v1/web_state.py
@@ -74,6 +74,26 @@ GET_INVERTER_REALTIME_DATA_SYSTEM = {
     },
 }
 
+GET_OHMPILOT_REALTIME_DATA_SYSTEM = {
+    "timestamp": {"value": "2019-06-24T10:10:44+02:00"},
+    "status": {"Code": 0, "Reason": "", "UserMessage": ""},
+    "ohmpilots": {
+        "0": {
+            "error_code": {"value": 926},
+            "state_code": {"value": 0},
+            "state_message": {"value": "Up and running"},
+            "hardware": {"value": "3"},
+            "manufacturer": {"value": "Fronius"},
+            "model": {"value": "Ohmpilot"},
+            "serial": {"value": "28136344"},
+            "software": {"value": "1.0.19-1"},
+            "energy_real_ac_consumed": {"value": 2964307, "unit": "Wh"},
+            "power_real_ac": {"value": 0, "unit": "W"},
+            "temperature_channel_1": {"value": 23.9, "unit": "°C"},
+        }
+    },
+}
+
 GET_LOGGER_LED_INFO_STATE = {
     "timestamp": {"value": "2019-06-23T23:50:16+02:00"},
     "status": {"Code": 0, "Reason": "", "UserMessage": ""},


### PR DESCRIPTION
Add support for Ohmpilot system scope request via `Fronius.current_system_ohmpilot_data()`

Test data is taken from Fronius SolarAPI V1 documentation. 
V0 doesn't support Ohmpilots.