### PR TITLE
Drop loop kwarg from asyncio.gather call

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -272,7 +272,6 @@ class Fronius:
         # storage is not necessarily supported by every fronius device
         device_storage=frozenset(["0"]),
         device_inverter=frozenset(["1"]),
-        loop=None,
     ):
         requests = []
         if active_device_info:
@@ -298,7 +297,7 @@ class Fronius:
         for i in device_inverter:
             requests.append(self.current_inverter_data(i))
 
-        res = await asyncio.gather(*requests, loop=loop, return_exceptions=True)
+        res = await asyncio.gather(*requests, return_exceptions=True)
         responses = []
         for result in res:
             if isinstance(result, FroniusError):


### PR DESCRIPTION
On Python 3.10 gather does not accept the loop kwarg anymore:

```
>       res = await asyncio.gather(*requests, loop=loop, return_exceptions=True)
E       TypeError: gather() got an unexpected keyword argument 'loop'
```

Tested against python 3.9/3.10.