### PR TITLE
Fetch 3PInverterData inverter data on API V1

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -302,6 +302,8 @@ class Fronius:
             requests.append(self.current_storage_data(i))
         for i in device_inverter:
             requests.append(self.current_inverter_data(i))
+        for i in device_inverter:
+            requests.append(self.current_inverter_3p_data(i))
 
         res = await asyncio.gather(*requests, return_exceptions=True)
         responses = []

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -82,6 +82,13 @@ URL_DEVICE_INVERTER_COMMON = {
         "DataCollection=CommonInverterData"
     ),
 }
+URL_DEVICE_INVERTER_3P = {
+    API_VERSION.V1: (
+        "GetInverterRealtimeData.cgi?Scope=Device&"
+        "DeviceId={}&"
+        "DataCollection=3PInverterData"
+    ),
+}
 URL_ACTIVE_DEVICE_INFO_SYSTEM = {
     API_VERSION.V1: "GetActiveDeviceInfo.cgi?DeviceClass=System"
 }
@@ -438,6 +445,17 @@ class Fronius:
             Fronius._device_inverter_data,
             URL_DEVICE_INVERTER_COMMON,
             "current inverter",
+            device,
+        )
+        
+    async def current_inverter_3p_data(self, device: str = "1") -> Dict[str, Any]:
+        """
+        Get the current inverter 3 phase data of one device.
+        """
+        return await self._current_data(
+            Fronius._device_inverter_3p_data,
+            URL_DEVICE_INVERTER_3P,
+            "current inverter 3p",
             device,
         )
 
@@ -972,6 +990,42 @@ class Fronius:
             if "LEDColor" in data["DeviceStatus"]:
                 sensor["led_color"] = {"value": data["DeviceStatus"]["LEDColor"]}
 
+        return sensor
+        
+    @staticmethod
+    def _device_inverter_3p_data(data):
+        _LOGGER.debug("Converting inverter 3p data from '{}'".format(data))
+        sensor = {}
+        if "IAC_L1" in data:
+            sensor["current_ac_phase_1"] = {
+                "value": data["IAC_L1"]["Value"],
+                "unit": data["IAC_L1"]["Unit"],
+            }
+        if "IAC_L2" in data:
+            sensor["current_ac_phase_2"] = {
+                "value": data["IAC_L2"]["Value"],
+                "unit": data["IAC_L2"]["Unit"],
+            }
+        if "IAC_L3" in data:
+            sensor["current_ac_phase_3"] = {
+                "value": data["IAC_L3"]["Value"],
+                "unit": data["IAC_L3"]["Unit"],
+            }
+        if "UAC_L1" in data:
+            sensor["voltage_ac_phase_1"] = {
+                "value": data["UAC_L1"]["Value"],
+                "unit": data["UAC_L1"]["Unit"],
+            }
+        if "UAC_L2" in data:
+            sensor["voltage_ac_phase_2"] = {
+                "value": data["UAC_L2"]["Value"],
+                "unit": data["UAC_L2"]["Unit"],
+            }
+        if "UAC_L3" in data:
+            sensor["voltage_ac_phase_3"] = {
+                "value": data["UAC_L3"]["Value"],
+                "unit": data["UAC_L3"]["Unit"],
+            }
         return sensor
 
     @staticmethod


### PR DESCRIPTION
V1 of the API allows fetching 3PInverterData, which contains voltage and current for the individual phases.

The data is only provided for inverters that support 3 phases. I don't own a single phase inverter, but according to some online research the data is returned empty without an error for those.

My use case is implementing support in home assistant for those 3p entities. I have a fork that successfully uses those entities and can provide a pull request as soon as this is merged and released.