### PR TITLE
Fetch 3PInverterData inverter data on API V1 #20

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -311,6 +311,8 @@ class Fronius:
             requests.append(self.current_storage_data(i))
         for i in device_inverter:
             requests.append(self.current_inverter_data(i))
+        for i in device_inverter:
+            requests.append(self.current_inverter_3p_data(i))
 
         res = await asyncio.gather(*requests, return_exceptions=True)
         responses = []

--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -84,6 +84,13 @@ URL_DEVICE_INVERTER_COMMON: Final = {
         "DataCollection=CommonInverterData"
     ),
 }
+URL_DEVICE_INVERTER_3P: Final = {
+    API_VERSION.V1: (
+        "GetInverterRealtimeData.cgi?Scope=Device&"
+        "DeviceId={}&"
+        "DataCollection=3PInverterData"
+    ),
+}
 URL_ACTIVE_DEVICE_INFO_SYSTEM: Final = {
     API_VERSION.V1: "GetActiveDeviceInfo.cgi?DeviceClass=System"
 }
@@ -452,6 +459,17 @@ class Fronius:
             Fronius._device_inverter_data,
             URL_DEVICE_INVERTER_COMMON,
             "current inverter",
+            device,
+        )
+        
+    async def current_inverter_3p_data(self, device: str = "1") -> Dict[str, Any]:
+        """
+        Get the current inverter 3 phase data of one device.
+        """
+        return await self._current_data(
+            Fronius._device_inverter_3p_data,
+            URL_DEVICE_INVERTER_3P,
+            "current inverter 3p",
             device,
         )
 
@@ -994,6 +1012,42 @@ class Fronius:
             if "LEDColor" in data["DeviceStatus"]:
                 sensor["led_color"] = {"value": data["DeviceStatus"]["LEDColor"]}
 
+        return sensor
+        
+    @staticmethod
+    def _device_inverter_3p_data(data):
+        _LOGGER.debug("Converting inverter 3p data from '{}'".format(data))
+        sensor = {}
+        if "IAC_L1" in data:
+            sensor["current_ac_phase_1"] = {
+                "value": data["IAC_L1"]["Value"],
+                "unit": data["IAC_L1"]["Unit"],
+            }
+        if "IAC_L2" in data:
+            sensor["current_ac_phase_2"] = {
+                "value": data["IAC_L2"]["Value"],
+                "unit": data["IAC_L2"]["Unit"],
+            }
+        if "IAC_L3" in data:
+            sensor["current_ac_phase_3"] = {
+                "value": data["IAC_L3"]["Value"],
+                "unit": data["IAC_L3"]["Unit"],
+            }
+        if "UAC_L1" in data:
+            sensor["voltage_ac_phase_1"] = {
+                "value": data["UAC_L1"]["Value"],
+                "unit": data["UAC_L1"]["Unit"],
+            }
+        if "UAC_L2" in data:
+            sensor["voltage_ac_phase_2"] = {
+                "value": data["UAC_L2"]["Value"],
+                "unit": data["UAC_L2"]["Unit"],
+            }
+        if "UAC_L3" in data:
+            sensor["voltage_ac_phase_3"] = {
+                "value": data["UAC_L3"]["Value"],
+                "unit": data["UAC_L3"]["Unit"],
+            }
         return sensor
 
     @staticmethod

--- a/tests/test_structure/v1/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceId=1&DataCollection=3PInverterData
+++ b/tests/test_structure/v1/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceId=1&DataCollection=3PInverterData
@@ -1,0 +1,43 @@
+{
+   "Body" : {
+      "Data" : {
+         "IAC_L1" : {
+            "Unit" : "A",
+            "Value" : 0.92972046136856079
+         },
+         "IAC_L2" : {
+            "Unit" : "A",
+            "Value" : 0.92731237411499023
+         },
+         "IAC_L3" : {
+            "Unit" : "A",
+            "Value" : 0.93189901113510132
+         },
+         "UAC_L1" : {
+            "Unit" : "V",
+            "Value" : 231.87258911132812
+         },
+         "UAC_L2" : {
+            "Unit" : "V",
+            "Value" : 231.79225158691406
+         },
+         "UAC_L3" : {
+            "Unit" : "V",
+            "Value" : 230.89854431152344
+         }
+      }
+   },
+   "Head" : {
+      "RequestArguments" : {
+         "DataCollection" : "3PInverterData",
+         "DeviceId" : "1",
+         "Scope" : "Device"
+      },
+      "Status" : {
+         "Code" : 0,
+         "Reason" : "",
+         "UserMessage" : ""
+      },
+      "Timestamp" : "2025-03-30T15:54:07+00:00"
+   }
+}

--- a/tests/test_web_v1.py
+++ b/tests/test_web_v1.py
@@ -22,6 +22,7 @@ from tests.web_raw.v1.web_state import (
     GET_METER_REALTIME_DATA_SCOPE_DEVICE,
     GET_STORAGE_REALTIME_DATA_SCOPE_DEVICE,
     GET_INVERTER_REALTIME_DATA_SCOPE_DEVICE,
+    GET_INVERTER_REALTIME_3P_DATA_SCOPE_DEVICE,
     GET_STORAGE_REALTIME_DATA_SYSTEM,
     GET_METER_REALTIME_DATA_SYSTEM,
     GET_LOGGER_LED_INFO_STATE,
@@ -192,6 +193,10 @@ class FroniusWebTestV1(AsyncTestCaseSetup):
         res = await self.fronius.current_inverter_data()
         self.assertDictEqual(res, GET_INVERTER_REALTIME_DATA_SCOPE_DEVICE)
 
+    async def test_fronius_get_inverter_realtime_3p_data_device(self):
+        res = await self.fronius.current_inverter_3p_data()
+        self.assertDictEqual(res, GET_INVERTER_REALTIME_3P_DATA_SCOPE_DEVICE)
+
     async def test_fronius_get_inverter_realtime_data_system(self):
         res = await self.fronius.current_system_inverter_data()
         self.assertDictEqual(res, GET_INVERTER_REALTIME_DATA_SYSTEM)
@@ -247,6 +252,7 @@ class FroniusWebTestV1(AsyncTestCaseSetup):
                 GET_METER_REALTIME_DATA_SCOPE_DEVICE,
                 GET_STORAGE_REALTIME_DATA_SCOPE_DEVICE,
                 GET_INVERTER_REALTIME_DATA_SCOPE_DEVICE,
+                GET_INVERTER_REALTIME_3P_DATA_SCOPE_DEVICE,
             ],
         )
 

--- a/tests/web_raw/v1/web_state.py
+++ b/tests/web_raw/v1/web_state.py
@@ -52,6 +52,17 @@ GET_INVERTER_REALTIME_DATA_SCOPE_DEVICE = {
     "led_color": {"value": 1},
 }
 
+GET_INVERTER_REALTIME_3P_DATA_SCOPE_DEVICE = {
+    "timestamp": {"value": "2025-03-30T15:54:07+00:00"},
+    "status": {"Code": 0, "Reason": "", "UserMessage": ""},
+    "current_ac_phase_1": {"value": 0.92972046136856079, "unit": "A"},
+    "current_ac_phase_2": {"value": 0.92731237411499023, "unit": "A"},
+    "current_ac_phase_3": {"value": 0.93189901113510132, "unit": "A"},
+    "voltage_ac_phase_1": {"value": 231.87258911132812, "unit": "V"},
+    "voltage_ac_phase_2": {"value": 231.79225158691406, "unit": "V"},
+    "voltage_ac_phase_3": {"value": 230.89854431152344, "unit": "V"},
+}
+
 GET_STORAGE_REALTIME_DATA_SCOPE_DEVICE_UNSUPPORTED = {
     "timestamp": {"value": "2019-01-10T23:33:14+01:00"},
     "status": {"Code": 255, "Reason": "Storages are not supported", "UserMessage": ""},


### PR DESCRIPTION


V1 of the API allows fetching 3PInverterData, which contains voltage and current for the individual phases.

The data is only provided for inverters that support 3 phases. I don't own a single phase inverter, but according to some online research the data is returned empty without an error for those.

My use case is implementing support in home assistant for those 3p entities. I have a fork that successfully uses those entities and can provide a pull request as soon as this is merged and released.
