### PR TITLE
Add callbacks for injecting functions

### DIFF
--- a/pyfronius/__init__.py
+++ b/pyfronius/__init__.py
@@ -390,123 +390,140 @@ class Fronius:
                 )
         return sensor
 
-    async def current_power_flow(self) -> Dict[str, Any]:
+    async def current_power_flow(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current power flow of a smart meter system.
         """
         return await self._current_data(
-            Fronius._system_power_flow, URL_POWER_FLOW, "current power flow"
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._system_power_flow,
+            URL_POWER_FLOW,
+            "current power flow"
         )
 
-    async def current_system_meter_data(self) -> Dict[str, Any]:
+    async def current_system_meter_data(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current meter data.
         """
         return await self._current_data(
-            Fronius._system_meter_data, URL_SYSTEM_METER, "current system meter"
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._system_meter_data,
+            URL_SYSTEM_METER,
+            "current system meter"
         )
 
-    async def current_system_inverter_data(self) -> Dict[str, Any]:
+    async def current_system_inverter_data(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current inverter data.
         The values are provided as cumulated values and for each inverter
         """
         return await self._current_data(
-            Fronius._system_inverter_data,
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._system_inverter_data,
             URL_SYSTEM_INVERTER,
             "current system inverter",
         )
 
-    async def current_system_ohmpilot_data(self) -> Dict[str, Any]:
+    async def current_system_ohmpilot_data(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current ohmpilot data.
         """
         return await self._current_data(
-            Fronius._system_ohmpilot_data,
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._system_ohmpilot_data,
             URL_SYSTEM_OHMPILOT,
             "current system ohmpilot",
         )
 
-    async def current_meter_data(self, device: str = "0") -> Dict[str, Any]:
+    async def current_meter_data(self, device: str = "0", ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current meter data for a device.
         """
         return await self._current_data(
-            Fronius._device_meter_data, URL_DEVICE_METER, "current meter", device
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._device_meter_data,
+            URL_DEVICE_METER,
+            "current meter", device
         )
 
-    async def current_storage_data(self, device: str = "0") -> Dict[str, Any]:
+    async def current_storage_data(self, device: str = "0", ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current storage data for a device.
         Provides data about batteries.
         """
         return await self._current_data(
-            Fronius._device_storage_data, URL_DEVICE_STORAGE, "current storage", device
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._device_storage_data,
+            URL_DEVICE_STORAGE,
+            "current storage",
+            device
         )
 
-    async def current_system_storage_data(self) -> Dict[str, Any]:
+    async def current_system_storage_data(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current storage data for a device.
         Provides data about batteries.
         """
         return await self._current_data(
-            Fronius._system_storage_data, URL_SYSTEM_STORAGE, "current system storage"
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._system_storage_data,
+            URL_SYSTEM_STORAGE,
+            "current system storage"
         )
 
-    async def current_inverter_data(self, device: str = "1") -> Dict[str, Any]:
+    async def current_inverter_data(self, device: str = "1", ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current inverter data of one device.
         """
         return await self._current_data(
-            Fronius._device_inverter_data,
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._device_inverter_data,
             URL_DEVICE_INVERTER_COMMON,
             "current inverter",
             device,
         )
 
-    async def current_inverter_3p_data(self, device: str = "1") -> Dict[str, Any]:
+    async def current_inverter_3p_data(self, device: str = "1", ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current inverter 3 phase data of one device.
         """
         return await self._current_data(
-            Fronius._device_inverter_3p_data,
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._device_inverter_3p_data,
             URL_DEVICE_INVERTER_3P,
             "current inverter 3p",
             device,
         )
 
-    async def current_led_data(self) -> Dict[str, Any]:
+    async def current_led_data(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current info led data for all LEDs
         """
         return await self._current_data(
-            Fronius._system_led_data, URL_SYSTEM_LED, "current led"
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._system_led_data,
+            URL_SYSTEM_LED,
+            "current led"
         )
 
-    async def current_active_device_info(self) -> Dict[str, Any]:
+    async def current_active_device_info(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get info about the current active devices in a smart meter system.
         """
         return await self._current_data(
-            Fronius._system_active_device_info,
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._system_active_device_info,
             URL_ACTIVE_DEVICE_INFO_SYSTEM,
             "current active device info",
         )
 
-    async def current_logger_info(self) -> Dict[str, Any]:
+    async def current_logger_info(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the current logger info of a smart meter system.
         """
         return await self._current_data(
-            Fronius._logger_info, URL_LOGGER_INFO, "current logger info"
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._logger_info,
+            URL_LOGGER_INFO,
+            "current logger info"
         )
 
-    async def inverter_info(self) -> Dict[str, Any]:
+    async def inverter_info(self, ext_cb_conversion: Callable[[Dict[str, Any]], Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Get the general infos of an inverter.
         """
         return await self._current_data(
-            Fronius._inverter_info, URL_INVERTER_INFO, "inverter info"
+            ext_cb_conversion if ext_cb_conversion is not None else Fronius._inverter_info,
+            URL_INVERTER_INFO,
+            "inverter info"
         )
 
     @staticmethod


### PR DESCRIPTION
As I need to process the raw JSON data from the HTTP responses, I've added optional callbacks to the methods which fetch the data from the Fronius device.

The callbacks are compatible with the private functions which convert the JSON data.

The usage is as follows:

```python
# the method I want to call
def my_power_flow(data: Dict[str, Any]):
# do my private stuff here


# the callback method, interface-compatbile with pyfronius.Fronius._system_power_flow
def power_flow_callback(data: Dict[str, Any]) -> Dict[str, Any]:
    my_power_flow(data)
    return pyfronius.Fronius._system_power_flow(data)


# using the API with the additional callback method
res = await fronius.current_power_flow(power_flow_callback)
```

The change does not break the current interface.